### PR TITLE
chore: Update GolangCI-Lint action to version v2.1.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
             go.sum
       - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:
-          version: v2.0.1
+          version: v2.1.6
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF


### PR DESCRIPTION
Upgraded the GolangCI-Lint GitHub Action from v2.0.1 to v2.1.6 to ensure compatibility with the latest features and fixes. This change helps maintain the reliability and robustness of the linting workflow.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
